### PR TITLE
feat: Add Claude command system for /slt and /gcm

### DIFF
--- a/.claude/commands/gcm.md
+++ b/.claude/commands/gcm.md
@@ -1,0 +1,1 @@
+Call scripts/gcm.sh with a one-line description of what the current work we've done since last commit does.

--- a/.claude/commands/slt.md
+++ b/.claude/commands/slt.md
@@ -1,0 +1,1 @@
+Call scripts/set_slt.sh with $ARGUMENT if at least one word, or with a summary of what we're working on of 5-10 words.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -753,10 +753,10 @@ See `docs/guides/integration-testing.md` and `docs/guides/testing-strategy.md` f
 ### Git Guidelines
 
 **Commits**: 
+- Do not use `git commit -m`. Instead use `/gcm`
 - No "Generated with Claude Code"
 - Descriptive messages explaining the purpose of changes
 - Use `git add [specific-files]` - NEVER `git add .` or `git add -A`
-- **Use `./scripts/gcm.sh` for commits** - Simplified commit script
 
 **Pushing**: 
 - Never force push

--- a/scripts/set_slt.sh
+++ b/scripts/set_slt.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Set Status Line Task script
+# Usage: ./scripts/set_slt.sh <task description>
+# Writes the provided task description to .claude-task file
+
+# Check if any parameters were provided
+if [ $# -eq 0 ]; then
+    echo "Error: Task description is required"
+    echo "Usage: $0 <task description>"
+    exit 1
+fi
+
+# Write all command line arguments to .claude-task
+echo "$*" > .claude-task
+
+echo "✓ Task set: $*"


### PR DESCRIPTION
## Summary
- Adds custom Claude command system with project-level commands
- Implements `/slt` command for setting statusline tasks  
- Implements `/gcm` command for git commits
- Updates CLAUDE.md to direct usage to `/gcm` instead of `git commit -m`

## Changes
- Created `.claude/commands/` directory for project-specific commands
- Added `scripts/set_slt.sh` - Script to set statusline task with validation
- Added `.claude/commands/slt.md` - Command definition for /slt
- Added `.claude/commands/gcm.md` - Command definition for /gcm  
- Updated CLAUDE.md with instruction to use `/gcm` for commits

## Test Plan
- [x] `/slt` command sets statusline task with provided text
- [x] `/slt` without arguments returns error (parameter required)
- [x] `/gcm` command creates git commit with statusline update
- [x] Commands integrate with existing gcm.sh script